### PR TITLE
Change Type from exec to forking

### DIFF
--- a/debian/webmin.service
+++ b/debian/webmin.service
@@ -6,7 +6,7 @@ StartLimitBurst=20
 StartLimitIntervalSec=30
 
 [Service]
-Type=exec
+Type=forking
 Environment="PERLLIB=/usr/share/webmin" LANG= PERLIO=
 ExecStart=/usr/share/webmin/miniserv.pl /etc/webmin/miniserv.conf
 KillSignal=SIGINT


### PR DESCRIPTION
Based on my testing, this fixes issues with Webmin not launching in LXC Containers.
Based on my understanding of systemd unit files, it is also the more correct way to be launching this particular service.